### PR TITLE
Register email fetch task with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ python -m celery -A server worker -P threads -l INFO -c 10 -Q celery --heartbeat
 python -m celery -A server flower -logging=info --url_prefix=api/flower --auto_refresh=False  --address=0.0.0.0 --port=5566
 ```
 
+## 邮箱配置与邮件拉取
+
+1. 在 `config.yml` 中启用邮件并配置服务器:
+
+   ```yaml
+   EMAIL_ENABLED: true
+   EMAIL_HOST: imap.example.com
+   EMAIL_PORT: 993
+   EMAIL_HOST_USER: "user@example.com"
+   EMAIL_HOST_PASSWORD: "password"
+   EMAIL_USE_SSL: true
+   ```
+
+2. 通过系统管理界面添加用户邮箱账号。
+
+3. Celery Beat 会自动创建名为 `system.fetch_user_emails` 的周期任务，每 5 分钟拉取一次新邮件并转成站内通知。亦可在 Django shell 中手动触发:
+
+   ```shell
+   python manage.py shell -c "from system.tasks_email import fetch_user_emails; fetch_user_emails.delay()"
+   ```
+
 ## 捐赠or鼓励
 
 如果你觉得这个项目帮助到了你，你可以[star](https://github.com/nineaiyu/xadmin-server)表示鼓励，也可以帮作者买一杯果汁🍹表示鼓励。

--- a/common/tasks.py
+++ b/common/tasks.py
@@ -121,6 +121,7 @@ def clean_celery_periodic_tasks():
 @after_app_ready_start
 def create_or_update_registered_periodic_tasks():
     from .celery.decorator import get_register_period_tasks
+    from system import tasks_email  # noqa: F401
     for task in get_register_period_tasks():
         create_or_update_celery_periodic_tasks(task)
 

--- a/system/tests/test_email.py
+++ b/system/tests/test_email.py
@@ -1,0 +1,97 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+from unittest.mock import patch, MagicMock
+
+from system.models import UserInfo, UserEmailAccount
+from system.views.email_account import UserEmailAccountViewSet
+from system.tasks_email import fetch_user_emails
+
+
+class BaseEmailTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        patcher = patch("system.signal_handler.batch_invalid_cache")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class UserEmailAccountModelTest(BaseEmailTest):
+    def test_password_encryption(self):
+        user = UserInfo.objects.create_user(username="u", password="p")
+        account = UserEmailAccount.objects.create(
+            user=user,
+            host="imap.example.com",
+            port=993,
+            protocol=UserEmailAccount.ProtocolChoices.IMAP,
+            username="u@example.com",
+            password="secret",
+        )
+        self.assertNotEqual(account._password, "secret")
+        self.assertEqual(account.password, "secret")
+
+
+class UserEmailAccountAPITest(BaseEmailTest):
+    def setUp(self):
+        super().setUp()
+        self.user = UserInfo.objects.create_superuser(
+            username="admin", password="admin", email="a@example.com"
+        )
+        self.factory = APIRequestFactory()
+
+    @patch("system.serializers.email_account.imaplib.IMAP4_SSL")
+    def test_create_account(self, mock_imap):
+        mock_imap.return_value = MagicMock()
+        payload = {
+            "user": str(self.user.id),
+            "host": "imap.example.com",
+            "port": 993,
+            "protocol": UserEmailAccount.ProtocolChoices.IMAP,
+            "username": "u@example.com",
+            "password": "secret",
+        }
+        request = self.factory.post("/api/system/email/account/", payload, format="json")
+        force_authenticate(request, user=self.user)
+        response = UserEmailAccountViewSet.as_view({"post": "create"})(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UserEmailAccount.objects.count(), 1)
+
+
+class FetchEmailsTaskTest(BaseEmailTest):
+    def setUp(self):
+        super().setUp()
+        user = UserInfo.objects.create_user(username="user", password="pass")
+        self.account = UserEmailAccount.objects.create(
+            user=user,
+            host="imap.example.com",
+            port=993,
+            protocol=UserEmailAccount.ProtocolChoices.IMAP,
+            username="u@example.com",
+            password="secret",
+        )
+
+    @patch("system.tasks_email.SiteMessageUtil.send_msg")
+    @patch("system.tasks_email.imaplib.IMAP4_SSL")
+    def test_fetch_emails(self, mock_imap, mock_send_msg):
+        class FakeIMAP:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def login(self, *args, **kwargs):
+                pass
+
+            def select(self, mailbox):
+                pass
+
+            def search(self, charset, criteria):
+                return "OK", [b"1"]
+
+            def fetch(self, num, spec):
+                msg = b"From: <a@example.com>\nSubject: hi\n\nbody"
+                return "OK", [(b"1 (UID 1)", msg)]
+
+            def logout(self):
+                pass
+
+        mock_imap.return_value = FakeIMAP()
+        fetch_user_emails()
+        mock_send_msg.assert_called_once()


### PR DESCRIPTION
## Summary
- ensure `system.fetch_user_emails` is discovered by periodic task registration
- document email configuration and manual fetch instructions
- add tests for user email account model, API and task fetching

## Testing
- `python manage.py test system.tests.test_email -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b90d9fea0483208a4b5e33b385d13b